### PR TITLE
Combine GroupKeyReset and GroupKeyRotate into GroupKeyAnnounce

### DIFF
--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -456,7 +456,7 @@ All Stream Layer messages have the following structure:
  `groupKeyId`| `string` | Identifies the AES key used by the publisher to encrypt the message content. For AES encryption, the `groupKeyId` is a unique identifier chosen by the publisher. If the message is RSA encrypted (used in key exchange), this field contains the public key of the intended recipient. The field is `null` if the message is not encrypted.
  `content` | `string` | Content data of the message. Depends on the `messageType` how the content should be handled.
  `signatureType` | `number` | Signature type as defined by the table below.
- `signature` | `string` | Signature of the message, signed by the producer. Encoding depends on the signature type.
+ `signature` | `string` | Signature of the message, signed by the publisher. A hex-encoded string.
 
 The various type fields have the following possible values:
 
@@ -488,15 +488,17 @@ Other content types, including binary types, will be defined in the future.
 -------------- | --------
 0 | Unencrypted, plaintext message.
 1 | Content is asymmetrically encrypted using RSA. When using RSA, the `groupKeyId` is set to the public key of the recipient. 
-2 | Content is symmetrically encrypted using AES. When using AES, the `groupKeyId` is set to a unique value chosen by the publisher, used to identify that particular key.
+2 | Content is symmetrically encrypted using AES. When using AES, the `groupKeyId` is set to a unique value freely chosen by the publisher, used to identify and refer to the key used.
 
 #### `signatureType`
 
 `signatureType` | Name | Description | Signature payload fields to be concatenated in order
 -------------- | ---- |------------ | -----------------------
 0 | `NONE` | No signature. The `signature` field is null in this case. | None.
-1 | `ETH_LEGACY` | Ethereum signature produced by old clients. The signature field is encoded as a hex string. | `streamId`, `streamPartition`, `timestamp`, `publisherId`, `content`
-2 | `ETH` | Ethereum signature produced by current clients (since Stream Layer version 30). The signature field is encoded as a hex string. | `streamId`, `streamPartition`, `timestamp`, `sequenceNumber`, `publisherId`, `msgChainId`, `prevMsgRef.timestamp`, `prevMsgRef.sequenceNumber`, `content`
+1 | `ETH_LEGACY` | Ethereum signature produced by old clients. The `signature` field is encoded as a hex-encoded string. | `streamId`, `streamPartition`, `timestamp`, `publisherId`, `content`
+2 | `ETH` | Ethereum signature produced by current clients (since Stream Layer version 30). The signature field is a hex-encoded string. | `streamId`, `streamPartition`, `timestamp`, `sequenceNumber`, `publisherId`, `msgChainId`, `prevMsgRef.timestamp` (if not null), `prevMsgRef.sequenceNumber` (if not null), `content`
+
+The concatenated payload is signed using the same [ECDSA and secp256k1 based method used in Ethereum](https://yos.io/2018/11/16/ethereum-signatures/).
 
 ### StreamMessage
 

--- a/validation.md
+++ b/validation.md
@@ -57,7 +57,7 @@ check that the signature is correct
 check that the publisher has stream_subscribe permission to S
 ```
 
-## GroupKeyResponse (messageType = 29) and GroupKeyReset (messageType = 30)
+## GroupKeyResponse (messageType = 29)
 
 ```
 let S be the stream for which the key response/reset is
@@ -67,11 +67,16 @@ check that the signature is correct
 check that the publisher has stream_publish permission to S
 ```
 
-## GroupKeyRotate (messageType = 30)
+## GroupKeyAnnounce (messageType = 30)
+
+`GroupKeyAnnounce` can be published on a subscriber's key exchange stream, or on the stream itself. This affects how they are validated:
 
 ```
-check that the message is signed and encrypted
-then validate the message as if it was a StreamMessage
+if (message is published on a key exchange stream) {
+    validate the message using the same logic as for GroupKeyResponse
+} else {
+    validate the message using the same logic as for StreamMessage
+}
 ```
 
 # Key exchange streams


### PR DESCRIPTION
A few things I realized only while working on a prototype implementation:

- `GroupKeyRotate` message type was added in the previous PR introducing v32, but it's actually redundant: `GroupKeyReset` is in practice the same message used in a different context. This PR combines both into `GroupKeyAnnounce`, which is now the only message type used to inform subscribers about new keys.

- Fix examples (content was not a string, although it should always be)

- Bring back the ability to attach a new `GroupKey` to a `StreamMessage` when rotating the key